### PR TITLE
Added upload and remove cover functionality with hover effect to editor

### DIFF
--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -21,13 +21,11 @@ export const ourFileRouter = {
       return { userId: user.id };
     })
     .onUploadComplete(async ({ metadata, file }) => {
-      // This code RUNS ON YOUR SERVER after upload
       console.log("Upload complete for userId:", metadata.userId);
-
       console.log("file url", file.url);
-
-      // !!! Whatever is returned here is sent to the clientside `onClientUploadComplete` callback
-      return { uploadedBy: metadata.userId };
+    
+      // Return the file URL along with the uploadedBy metadata
+      return { uploadedBy: metadata.userId, url: file.url }; // <-- Add the file URL here
     }),
 } satisfies FileRouter;
 

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,26 +1,70 @@
 "use client";
 import TextareaAutosize from "react-autosize-textarea";
-import { Button } from "@/components/ui/button";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import Cover from "@/components/Cover";
-//in onchange add the db call
+import { UploadButton } from "@uploadthing/react";
+
 export default function Home() {
+  const [coverUrl, setCoverUrl] = useState<string | null>(null);
+
   const Editor = useMemo(
     () => dynamic(() => import("@/components/Editor"), { ssr: false }),
     []
   );
 
+  // Function to remove cover
+  const handleRemoveCover = () => {
+    setCoverUrl(null);
+  };
+
   return (
     <main className="min-h-screen">
-      <Cover url="https://picsum.photos/200/300"/>
+      {/* Display the cover if there's a coverUrl */}
+      <div className="relative group">
+        <Cover url={coverUrl} />
+
+        {/* Show "Remove Cover" button only on hover over the cover */}
+        {coverUrl && (
+          <button
+            className="absolute bottom-2 left-2 opacity-0 group-hover:opacity-100 transition-opacity bg-neutral-100 text-neutral-400 rounded-md px-3 py-1"
+            onClick={handleRemoveCover}
+          >
+            ❌ Remove cover
+          </button>
+        )}
+      </div>
+
       <div className="flex flex-col px-24 py-10 w-full">
-        <TextareaAutosize
-          placeholder="Untitled"
-          className="w-full resize-none appearance-none overflow-hidden bg-transparent text-5xl font-bold focus:outline-none"
-          onPointerEnterCapture={undefined}
-          onPointerLeaveCapture={undefined}
-        />
+        <div className="group flex flex-col gap-2">
+          {/* Show Upload Button if no coverUrl is set */}
+          {!coverUrl && (
+            <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+              <UploadButton
+                className="hover:bg-neutral-100 text-neutral-400 rounded-md px-3 py-1 transition-colors w-fit ut-allowed-content:hidden ut-button:bg-neutral-200 ut-button:hover:bg-neutral-300 ut-button:text-neutral-800 ut-button:transition-colors"
+                endpoint="imageUploader"
+                content={{
+                  button({ ready }) {
+                    if (ready) return <div>📸 Add cover</div>;
+                    return "Getting ready...";
+                  },
+                }}
+                onClientUploadComplete={(res) => {
+                  console.log("Upload response:", res); // Log upload response
+                  if (res[0]) {
+                    setCoverUrl(res[0].url); // Set the uploaded image URL as the cover
+                  }
+                }}
+              />
+            </div>
+          )}
+
+          <TextareaAutosize
+            placeholder="Untitled"
+            className="w-full resize-none appearance-none overflow-hidden bg-transparent text-5xl font-bold focus:outline-none"
+          />
+        </div>
+
         <Editor onChange={() => {}} />
       </div>
     </main>

--- a/src/components/Cover.tsx
+++ b/src/components/Cover.tsx
@@ -2,17 +2,23 @@ import Image from 'next/image';
 import React from 'react';
 
 interface CoverProps {
-    url?: string;
+  url?: string;
 }
 
 const Cover: React.FC<CoverProps> = ({ url }) => {
-    return (
-        <div className='relative w-full h-[35vh] bg-neutral-200'>
-            {url && (
-                <Image src={url} alt='Cover' fill className='object-cover' sizes='100vw' />
-            )}
-        </div>
-    );
-}
+  return (
+    <div className={`relative w-full h-[35vh] bg-neutral-200 ${!url ? 'hidden' : ''}`}>
+      {url && (
+        <Image
+          src={url}
+          alt="Cover"
+          fill
+          className="object-cover"
+          sizes="100vw"
+        />
+      )}
+    </div>
+  );
+};
 
 export default Cover;


### PR DESCRIPTION
## Related Issue
"None”

## Description
This pull request adds the ability for users to upload and remove a cover image in the editor. The "Add Cover" button appears when no cover is set, and a "Remove Cover" button becomes visible at the bottom left of the cover image on hover, allowing users to easily change or remove the cover. These enhancements improve the overall user experience and visual appeal of the document editor.

## Type of PR

- [x] Feature enhancement

